### PR TITLE
修复排版

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -31,15 +31,15 @@ jobs:
     - name: Pull Container
       id: pull_container_image
       run: |
-        docker pull riscvintl/riscv-docs-base-container-image:latest
+        docker pull ghcr.io/ysyx-opendoc/asciidoctor:latest
 
     # Build PDF and HTML files using the container
     - name: Build Files
       id: build_files
       if: steps.pull_container_image.outcome == 'success'
       run: |
-        docker run --rm -v ${{ github.workspace }}:/build riscvintl/riscv-docs-base-container-image:latest \
-        /bin/sh -c 'cd ./build && make'
+        docker run --rm -v ${{ github.workspace }}:/build ghcr.io/ysyx-opendoc/asciidoctor:latest \
+        /bin/sh -c 'cd ./build/build && make'
 
     # Upload the unpriv-isa-asciidoc PDF file
     - name: Upload unpriv-isa-asciidoc.pdf

--- a/build/Makefile
+++ b/build/Makefile
@@ -34,7 +34,7 @@ ASCIIDOCTOR_OPTS := -a compress \
                     --require=asciidoctor-bibtex \
                     --require=asciidoctor-diagram \
                     --require=asciidoctor-mathematical \
-					-a scripts=cjk \
+										-a scripts=cjk \
                     --trace
 
 # Source directory

--- a/build/Makefile
+++ b/build/Makefile
@@ -25,7 +25,7 @@ all: $(TARGETS)
 # Build with preinstalled docker container; first install it with:
 #   docker pull riscvintl/riscv-docs-base-container-image:latest
 docker:
-	cd .. && docker run -it -v .:/build riscvintl/riscv-docs-base-container-image:latest /bin/sh -c 'cd ./build; make'
+	cd .. && docker run -it -v .:/build ghcr.io/ysyx-opendoc/asciidoctor:latest /bin/sh -c 'cd ./build/build; make'
 
 # Asciidoctor options
 ASCIIDOCTOR_OPTS := -a compress \
@@ -34,7 +34,7 @@ ASCIIDOCTOR_OPTS := -a compress \
                     --require=asciidoctor-bibtex \
                     --require=asciidoctor-diagram \
                     --require=asciidoctor-mathematical \
-										-a scripts=cjk \
+                    -a scripts=cjk \
                     --trace
 
 # Source directory

--- a/src/resources/themes/riscv-spec.yml
+++ b/src/resources/themes/riscv-spec.yml
@@ -3,14 +3,12 @@ font:
   catalog:
     merge: true
     sans-serif: GEM_FONTS_DIR/mplus1p-regular-fallback.ttf 
- #Petrona
     body:
-      normal: Petrona-Light.ttf
-      bold: Petrona-Medium.ttf
-      italic: Petrona-LightItalic.ttf
-      bold_italic: Petrona-MediumItalic.ttf
-      header_thin: Petrona-Thin.ttf
-  #Montserrat
+      normal: NotoSerifSC-Light.ttf
+      bold: NotoSerifSC-Medium.ttf
+      italic: NotoSerifSC-Light.ttf
+      bold_italic: NotoSerifSC-Medium.ttf
+      header_thin: NotoSerifSC-Light.ttf
     headings:
       normal: Montserrat-Regular.ttf
       italic: Montserrat-Italic.ttf
@@ -27,12 +25,6 @@ font:
       bold: mplus-1mn-bold.ttf
       italic: mplus-1mn-light.ttf
       bold_italic: mplus-1mn-medium.ttf
-    NotoSerif Fallback:
-      normal: NotoSerifSC-Light.ttf
-      bold: NotoSerifSC-Medium.ttf
-      italic: NotoSerifSC-Light.ttf
-      bold_italic: NotoSerifSC-Medium.ttf
-      header_thin: NotoSerifSC-Light.ttf
     M+ 1p Fallback:
       normal: mplus-1p-regular-fallback.ttf
       bold: mplus-1p-regular-fallback.ttf
@@ -43,10 +35,17 @@ font:
       italic: droid-sans-fallback.ttf
       bold: droid-sans-fallback.ttf
       bold_italic: droid-sans-fallback.ttf
+    Petrona Fallback:
+      normal: Petrona-Light.ttf
+      bold: Petrona-Medium.ttf
+      italic: Petrona-LightItalic.ttf
+      bold_italic: Petrona-MediumItalic.ttf
+      header_thin: Petrona-Thin.ttf
     # M+ 1p supports Latin, Latin-1 Supplement, Latin Extended, Greek, Cyrillic, Vietnamese, Japanese & an assortment of symbols
     # It also provides arrows for ->, <-, => and <= replacements in case these glyphs are missing from font
   fallbacks:
-    - NotoSerif Fallback
+    - body
+    - Petrona Fallback
     - M+ 1p Fallback
     - Droid Fallback
   svg:
@@ -60,7 +59,7 @@ page:
   margin_outer: 0.59in
   size: A4
 base:
-  font-family: body
+  font_family: body
   font_size: 11.5
   line_height_length: 12
   font_style: normal


### PR DESCRIPTION
修复了空格过大的问题

修复了中文标点被截断到新行的问题

修复了表格里中文被截断的问题

切换到了自己 fork 的工具链

仍然会有一些标点被截断到新行，原因是 asciidoctor 分词的时候把中文标点和后面的符号分在一起了。这个时候在中文标点后面加个空格就好